### PR TITLE
Update Composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "urlbox/screenshots",
-  "version": "3.0.0",
   "description": "Use urlbox to easily generate website thumbnail screenshots from a URL",
   "homepage": "https://github.com/urlbox/urlbox-php",
   "keywords": [


### PR DESCRIPTION
In this change, I have updated the composer.json to follow Packagist recommendations.

The default installation when running:

``` composer require urlbox/screenshots ```

remained as 3.0.0 due to 3.0.0 being the last tagged release on the github repo. Packagist follows the latest tagged release. Minor changes were made in Oct 2023, but a new tag was not created for those changes.

Because a new tagged release was not made (with the zipped source code), the updates did not take effect, meaning the default installation version did not include those Oct 2023 updates.

Additionally, if a tagged release were to be made without an update to the composer.json version, Packagist validation would have failed.

Packagist uses the command:

``` composer validate ```

to validate composer files, and when static versioning is provided it warns:

``` 
./composer.json is valid, but with a few warnings

See https://getcomposer.org/doc/04-schema.md for details on the schema

# General warnings

- The version field is present, it is recommended to leave it out if the package is published on Packagist.
```

This is recommended, because if there is a version mismatch (IE 3.0.0) with the latest tag (EG 3.0.1), it will fail validation and not upload to Packagist: 

https://blog.packagist.com/tagged-a-new-release-for-composer-and-it-wont-show-up-on-packagist/

As a result I have removed the static version from the composer.json. If merged into master, changes will only take effect if a new tagged release is made.

I believe the changes from Oct 2023 would fall under a minor change, as it is backward compatible, but introduces a new version of PSR7, and the flexibility to negate what would otherwise require an empty string in the place of the $webhookSecret to function EG: Urlbox::fromCredentials($key, $secret, '');

The change from October 2023 was made here:
https://github.com/urlbox/urlbox-php/commit/3c1a00bf0c13c3bab6a919cb1d2962b94792af5f

This would make the next release tag 3.1.0.